### PR TITLE
Fix `is_full` and `is_empty` on shared ring buffer

### DIFF
--- a/crates/sel4-shared-ring-buffer/src/lib.rs
+++ b/crates/sel4-shared-ring-buffer/src/lib.rs
@@ -149,11 +149,11 @@ impl<'a> RingBuffer<'a> {
     }
 
     pub fn is_empty(&self) -> bool {
-        Self::has_nonzero_residue(self.write_index() - self.read_index())
+        !Self::has_nonzero_residue(self.write_index() - self.read_index())
     }
 
     pub fn is_full(&self) -> bool {
-        Self::has_nonzero_residue(self.write_index() - self.read_index() + Wrapping(1))
+        !Self::has_nonzero_residue(self.write_index() - self.read_index() + Wrapping(1))
     }
 
     pub fn enqueue(&mut self, desc: Descriptor) -> Result<(), Error> {
@@ -181,6 +181,7 @@ impl<'a> RingBuffer<'a> {
     }
 }
 
+#[derive(Debug)]
 pub enum Error {
     RingIsFull,
     RingIsEmpty,


### PR DESCRIPTION
It looks like the `is_full` and `is_empty` checks on the rust shared ring buffer were returning the inverse of what they should. This attempts to fix that.

I also added `derive(Debug)` for the `Error` enum, since otherwise functions like `except` can't be used. Let me know if you'd prefer that in a separate PR.